### PR TITLE
use config to provide initial size and growth increments for the pool…

### DIFF
--- a/target.json
+++ b/target.json
@@ -17,5 +17,11 @@
     "armcc",
     "mbed"
   ],
+  "config": {
+    "minar" : {
+      "initial_event_pool_size"     : 50,
+      "additional_event_pools_size" : 100
+    }
+  },
   "toolchain": "CMake/toolchain.cmake"
 }


### PR DESCRIPTION
… of minar::CallbackNodes

This is needed for supporting nRF5x where sizes need to be constrained.