### PR TITLE
Workaround armcc bug on windows.

### DIFF
--- a/CMake/Platform/mbedOS-ARMCC-C.cmake
+++ b/CMake/Platform/mbedOS-ARMCC-C.cmake
@@ -13,7 +13,17 @@ set(CMAKE_C_CREATE_SHARED_MODULE  "echo 'shared modules not supported' && 1")
 set(CMAKE_C_CREATE_STATIC_LIBRARY "<CMAKE_AR> -cr<LINK_FLAGS> <TARGET> <OBJECTS>")
 set(CMAKE_C_COMPILE_OBJECT        "${ARMCC_ENV} <CMAKE_C_COMPILER> ${YOTTA_TARGET_DEFINITIONS} <DEFINES> --gnu -c <FLAGS> -o <OBJECT> <SOURCE>")
 set(CMAKE_C_LINK_EXECUTABLE       "<CMAKE_LINKER> -o <TARGET> <OBJECTS> <LINK_LIBRARIES> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS>")
-set(CMAKE_ASM_COMPILE_OBJECT      "${ARMCC_ENV} <CMAKE_C_COMPILER> ${YOTTA_TARGET_DEFINITIONS} <DEFINES> --gnu -c <FLAGS> -o <OBJECT> <SOURCE>")
+# fun fact! armcc doesn't preprocess .S files on windows (that's uppercase .s)
+# like gcc does (and like it does itself on Linux). So, we have to squeeze in
+# an explicit preprocessing step here. We only do it on windows because it
+# seems a bit risky...
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+    # to do && we need to put an explicit cmd.exe /C in here: This is how CMake
+    # composes other composite commands for Ninja, so we should be safe
+    set(CMAKE_ASM_COMPILE_OBJECT      "cmd.exe /C <CMAKE_C_COMPILER> ${YOTTA_TARGET_DEFINITIONS} <DEFINES> --gnu -E <FLAGS> -o <OBJECT>.pp.s <SOURCE> && <CMAKE_C_COMPILER> <DEFINES> --gnu --c90 -c <FLAGS> -o <OBJECT> <OBJECT>.pp.s")
+else()
+    set(CMAKE_ASM_COMPILE_OBJECT      "${ARMCC_ENV} <CMAKE_C_COMPILER> ${YOTTA_TARGET_DEFINITIONS} <DEFINES> --gnu -c <FLAGS> -o <OBJECT> <SOURCE>")
+endif()
 
 set(CMAKE_C_FLAGS_DEBUG_INIT          "-O0 -g")
 set(CMAKE_C_FLAGS_MINSIZEREL_INIT     "-Ospace -DNDEBUG")

--- a/CMake/Platform/mbedOS-ARMCC-C.cmake
+++ b/CMake/Platform/mbedOS-ARMCC-C.cmake
@@ -11,7 +11,7 @@ endif()
 set(CMAKE_C_CREATE_SHARED_LIBRARY "echo 'shared libraries not supported' && 1")
 set(CMAKE_C_CREATE_SHARED_MODULE  "echo 'shared modules not supported' && 1")
 set(CMAKE_C_CREATE_STATIC_LIBRARY "<CMAKE_AR> -cr<LINK_FLAGS> <TARGET> <OBJECTS>")
-set(CMAKE_C_COMPILE_OBJECT        "${ARMCC_ENV} <CMAKE_C_COMPILER> ${YOTTA_TARGET_DEFINITIONS} <DEFINES> --gnu -c <FLAGS> -o <OBJECT> <SOURCE>")
+set(CMAKE_C_COMPILE_OBJECT        "${ARMCC_ENV} <CMAKE_C_COMPILER> <DEFINES> --gnu -c <FLAGS> -o <OBJECT> <SOURCE>")
 set(CMAKE_C_LINK_EXECUTABLE       "<CMAKE_LINKER> -o <TARGET> <OBJECTS> <LINK_LIBRARIES> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS>")
 # fun fact! armcc doesn't preprocess .S files on windows (that's uppercase .s)
 # like gcc does (and like it does itself on Linux). So, we have to squeeze in
@@ -20,9 +20,9 @@ set(CMAKE_C_LINK_EXECUTABLE       "<CMAKE_LINKER> -o <TARGET> <OBJECTS> <LINK_LI
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
     # to do && we need to put an explicit cmd.exe /C in here: This is how CMake
     # composes other composite commands for Ninja, so we should be safe
-    set(CMAKE_ASM_COMPILE_OBJECT      "cmd.exe /C <CMAKE_C_COMPILER> ${YOTTA_TARGET_DEFINITIONS} <DEFINES> --gnu -E <FLAGS> -o <OBJECT>.pp.s <SOURCE> && <CMAKE_C_COMPILER> <DEFINES> --gnu --c90 -c <FLAGS> -o <OBJECT> <OBJECT>.pp.s")
+    set(CMAKE_ASM_COMPILE_OBJECT      "cmd.exe /C <CMAKE_C_COMPILER> <DEFINES> --gnu -E <FLAGS> -o <OBJECT>.pp.s <SOURCE> && <CMAKE_C_COMPILER> <DEFINES> --gnu --c90 -c <FLAGS> -o <OBJECT> <OBJECT>.pp.s")
 else()
-    set(CMAKE_ASM_COMPILE_OBJECT      "${ARMCC_ENV} <CMAKE_C_COMPILER> ${YOTTA_TARGET_DEFINITIONS} <DEFINES> --gnu -c <FLAGS> -o <OBJECT> <SOURCE>")
+    set(CMAKE_ASM_COMPILE_OBJECT      "${ARMCC_ENV} <CMAKE_C_COMPILER> <DEFINES> --gnu -c <FLAGS> -o <OBJECT> <SOURCE>")
 endif()
 
 set(CMAKE_C_FLAGS_DEBUG_INIT          "-O0 -g")


### PR DESCRIPTION
armcc doesn't preprocess .S files on windows, so we have to add an explicit
preprocessing step to do this. To do that, use call cmd.exe explicitly, and use
&& to chain the two commands. This is the same way that CMake composes other
composite commands for Ninja, so this should be a relatively safe thing to do.

@bogdanm @0xc0170 