### PR TITLE
Add a default baud rate of 9600

### DIFF
--- a/target.json
+++ b/target.json
@@ -23,6 +23,11 @@
     "mbed"
   ],
   "config": {
+      "mbed-os" : {
+          "stdio" : {
+              "default-baud" : 9600
+          }
+      },
     "minar": {
       "initial_event_pool_size": 50,
       "additional_event_pools_size": 100


### PR DESCRIPTION
This will stop https://github.com/ARMmbed/mbed-drivers/pull/128 from breaking test jobs until mbedgt can extract the default baud from yotta config.

cc @bogdanm @PrzemekWirkus 